### PR TITLE
[bugfix] missing class method

### DIFF
--- a/lib/fluent/plugin/in_pcapng.rb
+++ b/lib/fluent/plugin/in_pcapng.rb
@@ -96,7 +96,7 @@ module Fluent
     def build_options(fields)
       options = ""
       fields.each do |field|
-        options += "-e #{Shellwords.escape(field)}"
+        options += "-e #{Shellwords.escape(field)} "
       end
       return options
     end

--- a/lib/fluent/plugin/in_pcapng.rb
+++ b/lib/fluent/plugin/in_pcapng.rb
@@ -77,7 +77,7 @@ module Fluent
     def run
       options = build_options(@fields)
       options += build_extra_flags(@extra_flags)
-      cmdline = "tshark -i #{Shellwords(@interface)} -T fields -E separator=\",\" -E quote=d #{options}"
+      cmdline = "tshark -i #{Shellwords.escape(@interface)} -T fields -E separator=\",\" -E quote=d #{options}"
       log.debug format("pcapng: %s", cmdline)
       _stdin, stdout, stderr, @th_tshark = *Open3.popen3(cmdline)
 

--- a/test/test_in_ngpcap.rb
+++ b/test/test_in_ngpcap.rb
@@ -72,4 +72,9 @@ class PcapngInputTest < Test::Unit::TestCase
     instance = create_driver(config).instance
     assert_raise ArgumentError do instance.build_extra_flags(instance.extra_flags) end
   end
+
+  def test_build_options_with_valid_flags
+    instance = create_driver.instance
+    assert_equal "-e frame.time_epoch -e dns.qry.name -e dns.qry.type -e dns.qry.class -e dns.id -e ip.src -e ip.dst ", instance.build_options(instance.fields)
+  end
 end


### PR DESCRIPTION
fixes a regression in the previous PR, "undefined method `Shellwords' for #<Fluent::PcapngInput:0x00000806d90900>" and invalid options passed to `tshark`

sorry for the regression, the plugin has been tested in a staging environment this time.